### PR TITLE
Prevent window lines from being selected for wlist

### DIFF
--- a/wmequalize.py
+++ b/wmequalize.py
@@ -119,7 +119,7 @@ def parse_windows(wlist):
 
 def generate_windows():
 
-    wlist = os.popen("wmiir read /tag/sel/index | grep \# | grep -v \~ | cut -c 3-").readlines()
+    wlist = os.popen("wmiir read /tag/sel/index | grep ^\# | grep -v \~ | cut -c 3-").readlines()
 
     windows = parse_windows(wlist)
     desktops = build_desktops(windows)


### PR DESCRIPTION
Window titles with `#` characters are currently selected by the `grep` invocation. Only the lines starting with `#` should be selected, so this change anchors the regex to the start of the line.